### PR TITLE
Port over example behaviors from `moveit_studio_example_behaviors`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,11 @@ cmake_minimum_required(VERSION 3.22)
 project(lab_sim)
 
 find_package(ament_cmake REQUIRED)
-find_package(picknik_accessories REQUIRED)
 
+find_package(example_interfaces REQUIRED)
+find_package(moveit_studio_behavior_interface REQUIRED)
+find_package(picknik_accessories REQUIRED)
+find_package(pluginlib REQUIRED)
 
 # Install all XML files in directory
 set(PICKNIK_ACCESSORIES_SHARE_DIR
@@ -12,9 +15,30 @@ set(PICKNIK_ACCESSORIES_SHARE_DIR
 # Destination directory
 set(DEST_DIR "${CMAKE_INSTALL_PREFIX}/share/${PROJECT_NAME}/description/")
 
+set(THIS_PACKAGE_INCLUDE_DEPENDS moveit_studio_behavior_interface pluginlib
+                                 example_interfaces)
+
 install(DIRECTORY "${PICKNIK_ACCESSORIES_SHARE_DIR}"
         DESTINATION "${DEST_DIR}"
         FILES_MATCHING PATTERN "*")
+
+add_library(
+  example_behaviors SHARED
+  src/hello_world.cpp
+  src/delayed_message.cpp
+  src/setup_mtc_wave_hand.cpp
+  src/register_behaviors.cpp
+  src/add_two_ints_service_client.cpp
+  src/fibonacci_action_client.cpp
+  src/get_string_from_topic.cpp
+  src/publish_color_rgba.cpp
+  src/setup_mtc_pick_from_pose.cpp
+  src/setup_mtc_place_from_pose.cpp)
+target_include_directories(
+  example_behaviors
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+         $<INSTALL_INTERFACE:include>)
+ament_target_dependencies(example_behaviors ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 # Install individual XML files
 # set(EXTERNAL_XML_FILES
@@ -27,6 +51,16 @@ install(DIRECTORY "${PICKNIK_ACCESSORIES_SHARE_DIR}"
 #           DESTINATION "${DEST_DIR}"
 #   )
 # endforeach()
+
+# Install Libraries
+install(
+  TARGETS example_behaviors
+  EXPORT example_behaviorsTargets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES
+  DESTINATION include)
 
 install(
   DIRECTORY
@@ -44,4 +78,12 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
+# Export the behavior plugins defined in this package so they are available to
+# plugin loaders that load the behavior base class library from the
+# moveit_studio_behavior package.
+pluginlib_export_plugin_description_file(
+  moveit_studio_behavior_interface example_behaviors_plugin_description.xml)
+
+ament_export_targets(example_behaviorsTargets HAS_LIBRARY_TARGET)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 ament_package()

--- a/behavior_plugin.yaml
+++ b/behavior_plugin.yaml
@@ -1,0 +1,4 @@
+objectives:
+  behavior_loader_plugins:
+    moveit_studio_example_behaviors:
+      - "example_behaviors::ExampleBehaviorsLoader"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -43,6 +43,7 @@ objectives:
       - "moveit_studio::behaviors::ServoBehaviorsLoader"
       - "moveit_studio::behaviors::VisionBehaviorsLoader"
       - "picknik_registration::PicknikRegistrationBehaviorsLoader"
+      - "example_behaviors::ExampleBehaviorsLoader"
   # Specify source folder for objectives
   # [Required]
   objective_library_paths:

--- a/example_behaviors_plugin_description.xml
+++ b/example_behaviors_plugin_description.xml
@@ -1,0 +1,5 @@
+<library path="example_behaviors">
+  <class type="example_behaviors::ExampleBehaviorsLoader"
+         base_class_type="moveit_studio::behaviors::SharedResourcesNodeLoaderBase">
+  </class>
+</library>

--- a/include/example_behaviors/add_two_ints_service_client.hpp
+++ b/include/example_behaviors/add_two_ints_service_client.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <moveit_studio_behavior_interface/service_client_behavior_base.hpp>
+#include <example_interfaces/srv/add_two_ints.hpp>
+
+using moveit_studio::behaviors::BehaviorContext;
+using moveit_studio::behaviors::ServiceClientBehaviorBase;
+using AddTwoInts = example_interfaces::srv::AddTwoInts;
+
+namespace example_behaviors
+{
+class AddTwoIntsServiceClient final : public ServiceClientBehaviorBase<AddTwoInts>
+{
+public:
+  AddTwoIntsServiceClient(const std::string& name, const BT::NodeConfiguration& config,
+                          const std::shared_ptr<BehaviorContext>& shared_resources);
+
+  /** @brief Implementation of the required providedPorts() function for the hello_world Behavior. */
+  static BT::PortsList providedPorts();
+
+  /**
+   * @brief Implementation of the metadata() function for displaying metadata, such as Behavior description and
+   * subcategory, in the MoveIt Studio Developer Tool.
+   * @return A BT::KeyValueVector containing the Behavior metadata.
+   */
+  static BT::KeyValueVector metadata();
+
+private:
+  /** @brief User-provided function to get the name of the service when initializing the service client. */
+  tl::expected<std::string, std::string> getServiceName() override;
+
+  /**
+   * @brief User-provided function to create the service request.
+   * @return Returns a service request message. If not successful, returns an error message. Note that the criteria for
+   * success or failure is defined by the user's implementation of this function.
+   */
+  tl::expected<AddTwoInts::Request, std::string> createRequest() override;
+
+  /** @brief Optional user-provided function to process the service response after the service has finished. */
+  tl::expected<bool, std::string> processResponse(const AddTwoInts::Response& response) override;
+
+  /** @brief Classes derived from AsyncBehaviorBase must implement getFuture() so that it returns a shared_future class member */
+  std::shared_future<tl::expected<bool, std::string>>& getFuture() override
+  {
+    return future_;
+  }
+
+  /** @brief Classes derived from AsyncBehaviorBase must have this shared_future as a class member */
+  std::shared_future<tl::expected<bool, std::string>> future_;
+};
+}  // namespace example_behaviors

--- a/include/example_behaviors/delayed_message.hpp
+++ b/include/example_behaviors/delayed_message.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <behaviortree_cpp/action_node.h>
+
+// This header includes the SharedResourcesNode type
+#include <moveit_studio_behavior_interface/shared_resources_node.hpp>
+
+#include <moveit_msgs/msg/move_it_error_codes.hpp>
+
+#include <moveit_studio_behavior_interface/check_for_error.hpp>
+
+namespace example_behaviors
+{
+/**
+ * @brief DelayedMessage will use FailureLoggerROS to log a "Hello World" message after the duration specified on the input port
+ */
+class DelayedMessage : public moveit_studio::behaviors::SharedResourcesNode<BT::StatefulActionNode>
+{
+private:
+  std::chrono::time_point<std::chrono::steady_clock> start_time_;
+  double delay_duration_;
+
+public:
+  /**
+   * @brief Constructor for the delayed_message behavior.
+   * @param name The name of a particular instance of this Behavior. This will be set by the behavior tree factory when
+   * this Behavior is created within a new behavior tree.
+   * @param shared_resources A shared_ptr to a BehaviorContext that is shared among all SharedResourcesNode Behaviors in
+   * the behavior tree. This BehaviorContext is owned by the Studio Agent's ObjectiveServerNode.
+   * @param config This contains runtime configuration info for this Behavior, such as the mapping between the
+   * Behavior's data ports on the behavior tree's blackboard. This will be set by the behavior tree factory when this
+   * Behavior is created within a new behavior tree.
+   * @details An important limitation is that the members of the base Behavior class are not instantiated until after
+   * the initialize() function is called, so these classes should not be used within the constructor.
+   */
+  DelayedMessage(const std::string& name, const BT::NodeConfiguration& config,
+                 const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
+
+  /**
+   * @brief Implementation of the required providedPorts() function for the delayed_message Behavior.
+   * @details The BehaviorTree.CPP library requires that Behaviors must implement a static function named
+   * providedPorts() which defines their input and output ports. If the Behavior does not use any ports, this function
+   * must return an empty BT::PortsList. This function returns a list of ports with their names and port info, which is
+   * used internally by the behavior tree.
+   * @return If delayed_message does not expose any ports, this function returns an empty list.
+   */
+  static BT::PortsList providedPorts();
+
+  /**
+   * @brief Implementation of the metadata() function for displaying metadata, such as Behavior description and
+   * subcategory, in the MoveIt Studio Developer Tool.
+   * @return A BT::KeyValueVector containing the Behavior metadata.
+   */
+  static BT::KeyValueVector metadata();
+
+  /**
+   * @brief Implementation of onStart(). Runs when the Behavior is ticked for the first time.
+   * @return Always returns BT::NodeStatus::RUNNING, since the success of Behavior's initialization is checked in @ref
+   * onRunning().
+   */
+  BT::NodeStatus onStart() override;
+
+  /**
+   * @brief Implementation of onRunning(). Checks the status of the Behavior when it is ticked after it starts running.
+   * @return BT::NodeStatus::RUNNING, BT::NodeStatus::SUCCESS, or BT::NodeStatus::FAILURE depending on the Behavior status.
+   */
+  BT::NodeStatus onRunning() override;
+
+  void onHalted() override;
+};
+}  // namespace example_behaviors

--- a/include/example_behaviors/fibonacci_action_client.hpp
+++ b/include/example_behaviors/fibonacci_action_client.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <moveit_studio_behavior_interface/action_client_behavior_base.hpp>
+#include <example_interfaces/action/fibonacci.hpp>
+
+using moveit_studio::behaviors::ActionClientBehaviorBase;
+using moveit_studio::behaviors::BehaviorContext;
+using Fibonacci = example_interfaces::action::Fibonacci;
+
+namespace example_behaviors
+{
+class FibonacciActionClient final : public ActionClientBehaviorBase<Fibonacci>
+{
+public:
+  FibonacciActionClient(const std::string& name, const BT::NodeConfiguration& config,
+                        const std::shared_ptr<BehaviorContext>& shared_resources);
+
+  /** @brief Implementation of the required providedPorts() function for the hello_world Behavior. */
+  static BT::PortsList providedPorts();
+
+  /**
+   * @brief Implementation of the metadata() function for displaying metadata, such as Behavior description and
+   * subcategory, in the MoveIt Studio Developer Tool.
+   * @return A BT::KeyValueVector containing the Behavior metadata.
+   */
+  static BT::KeyValueVector metadata();
+
+private:
+  /** @brief User-provided function to get the name of the action when initializing the action client. */
+  tl::expected<std::string, std::string> getActionName() override;
+
+  /** @brief User-provided function to create the action goal before sending the action goal request. */
+  tl::expected<Fibonacci::Goal, std::string> createGoal() override;
+
+  /** @brief Optional user-provided function to process the action result after the action has finished. */
+  tl::expected<bool, std::string> processResult(const std::shared_ptr<Fibonacci::Result> result) override;
+
+  /** @brief Optional user-provided function to process feedback sent by the action server. */
+  void processFeedback(const std::shared_ptr<const Fibonacci::Feedback> feedback) override;
+
+  /** @brief Classes derived from AsyncBehaviorBase must implement getFuture() so that it returns a shared_future class member */
+  std::shared_future<tl::expected<bool, std::string>>& getFuture() override
+  {
+    return future_;
+  }
+
+  /** @brief Classes derived from AsyncBehaviorBase must have this shared_future as a class member */
+  std::shared_future<tl::expected<bool, std::string>> future_;
+};
+}  // namespace example_behaviors

--- a/include/example_behaviors/get_string_from_topic.hpp
+++ b/include/example_behaviors/get_string_from_topic.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <moveit_studio_behavior_interface/get_message_from_topic.hpp>
+#include <std_msgs/msg/string.hpp>
+
+using moveit_studio::behaviors::BehaviorContext;
+using moveit_studio::behaviors::GetMessageFromTopicBehaviorBase;
+
+namespace example_behaviors
+{
+class GetStringFromTopic final : public GetMessageFromTopicBehaviorBase<std_msgs::msg::String>
+{
+public:
+  GetStringFromTopic(const std::string& name, const BT::NodeConfiguration& config,
+                     const std::shared_ptr<BehaviorContext>& shared_resources);
+
+  /** @brief Implementation of the required providedPorts() function for the hello_world Behavior. */
+  static BT::PortsList providedPorts();
+
+  /**
+   * @brief Implementation of the metadata() function for displaying metadata, such as Behavior description and
+   * subcategory, in the MoveIt Studio Developer Tool.
+   * @return A BT::KeyValueVector containing the Behavior metadata.
+   */
+  static BT::KeyValueVector metadata();
+
+private:
+  /** @brief Classes derived from AsyncBehaviorBase must implement getFuture() so that it returns a shared_future class member */
+  std::shared_future<tl::expected<bool, std::string>>& getFuture() override
+  {
+    return future_;
+  }
+
+  /** @brief Classes derived from AsyncBehaviorBase must have this shared_future as a class member */
+  std::shared_future<tl::expected<bool, std::string>> future_;
+};
+}  // namespace example_behaviors

--- a/include/example_behaviors/hello_world.hpp
+++ b/include/example_behaviors/hello_world.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <behaviortree_cpp/action_node.h>
+
+// This header includes the SharedResourcesNode type
+#include <moveit_studio_behavior_interface/shared_resources_node.hpp>
+
+namespace example_behaviors
+{
+/**
+ * @brief The HelloWorld Behavior uses FailureLoggerROS to log a "Hello World" message and will always return SUCCESS
+ */
+class HelloWorld : public moveit_studio::behaviors::SharedResourcesNode<BT::SyncActionNode>
+{
+public:
+  /**
+   * @brief Constructor for the hello_world behavior.
+   * @param name The name of a particular instance of this Behavior. This will be set by the behavior tree factory when
+   * this Behavior is created within a new behavior tree.
+   * @param shared_resources A shared_ptr to a BehaviorContext that is shared among all SharedResourcesNode Behaviors in
+   * the behavior tree. This BehaviorContext is owned by the Studio Agent's ObjectiveServerNode.
+   * @param config This contains runtime configuration info for this Behavior, such as the mapping between the
+   * Behavior's data ports on the behavior tree's blackboard. This will be set by the behavior tree factory when this
+   * Behavior is created within a new behavior tree.
+   * @details An important limitation is that the members of the base Behavior class are not instantiated until after
+   * the initialize() function is called, so these classes should not be used within the constructor.
+   */
+  HelloWorld(const std::string& name, const BT::NodeConfiguration& config,
+             const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
+
+  /**
+   * @brief Implementation of the required providedPorts() function for the hello_world Behavior.
+   * @details The BehaviorTree.CPP library requires that Behaviors must implement a static function named
+   * providedPorts() which defines their input and output ports. If the Behavior does not use any ports, this function
+   * must return an empty BT::PortsList. This function returns a list of ports with their names and port info, which is
+   * used internally by the behavior tree.
+   * @return hello_world does not expose any ports, so this function returns an empty list.
+   */
+  static BT::PortsList providedPorts();
+
+  /**
+   * @brief Implementation of the metadata() function for displaying metadata, such as Behavior description and
+   * subcategory, in the MoveIt Studio Developer Tool.
+   * @return A BT::KeyValueVector containing the Behavior metadata.
+   */
+  static BT::KeyValueVector metadata();
+
+  /**
+   * @brief Implementation of BT::SyncActionNode::tick() for HelloWorld.
+   * @details This function is where the Behavior performs its work when the behavior tree is being run.
+   * Since HelloWorld is derived from BT::SyncActionNode, it is very important that its tick() function always finishes
+   * very quickly. If tick() blocks before returning, it will block execution of the entire behavior tree, which may
+   * have undesirable consequences for other Behaviors that require a fast update rate to work correctly.
+   * @return BT::NodeStatus::RUNNING, BT::NodeStatus::SUCCESS, or BT::NodeStatus::FAILURE depending on the result of the
+   * work done in this function.
+   */
+  BT::NodeStatus tick() override;
+};
+}  // namespace example_behaviors

--- a/include/example_behaviors/publish_color_rgba.hpp
+++ b/include/example_behaviors/publish_color_rgba.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <behaviortree_cpp/action_node.h>
+#include <behaviortree_cpp/bt_factory.h>
+#include <moveit_studio_behavior_interface/behavior_context.hpp>
+#include <moveit_studio_behavior_interface/shared_resources_node.hpp>
+#include <rclcpp/publisher.hpp>
+#include <std_msgs/msg/color_rgba.hpp>
+
+#include <memory>
+#include <string>
+
+namespace example_behaviors
+{
+class PublishColorRGBA final : public moveit_studio::behaviors::SharedResourcesNode<BT::SyncActionNode>
+{
+public:
+  PublishColorRGBA(const std::string& name, const BT::NodeConfiguration& config,
+                   const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
+
+  static BT::PortsList providedPorts();
+
+  static BT::KeyValueVector metadata();
+
+  BT::NodeStatus tick() override;
+
+private:
+  std::shared_ptr<rclcpp::Publisher<std_msgs::msg::ColorRGBA>> publisher_;
+};
+}  // namespace example_behaviors

--- a/include/example_behaviors/setup_mtc_pick_from_pose.hpp
+++ b/include/example_behaviors/setup_mtc_pick_from_pose.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <behaviortree_cpp/action_node.h>
+#include <behaviortree_cpp/bt_factory.h>
+#include <moveit_studio_behavior_interface/behavior_context.hpp>
+#include <moveit_studio_behavior_interface/shared_resources_node.hpp>
+
+namespace example_behaviors
+{
+/**
+ * @brief Given an existing MTC Task object and a target grasp pose, appends MTC stages to describe a motion plan to
+ * approach, grasp, and lift an object at that pose.
+ *
+ * @details
+ * | Data Port Name | Port Type     | Object Type                                     |
+ * | -------------- |---------------|-------------------------------------------------|
+ * | task           | Bidirectional | std::shared_ptr<moveit::task_constructor::Task> |
+ * | grasp_pose     | Input         | geometry_msgs::msg::PoseStamped                 |
+ */
+class SetupMtcPickFromPose final : public moveit_studio::behaviors::SharedResourcesNode<BT::SyncActionNode>
+{
+public:
+  SetupMtcPickFromPose(const std::string& name, const BT::NodeConfiguration& config,
+                       const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
+
+  static BT::PortsList providedPorts();
+
+  static BT::KeyValueVector metadata();
+
+  BT::NodeStatus tick() override;
+};
+}  // namespace example_behaviors

--- a/include/example_behaviors/setup_mtc_place_from_pose.hpp
+++ b/include/example_behaviors/setup_mtc_place_from_pose.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <behaviortree_cpp/action_node.h>
+#include <behaviortree_cpp/bt_factory.h>
+#include <moveit_studio_behavior_interface/behavior_context.hpp>
+#include <moveit_studio_behavior_interface/shared_resources_node.hpp>
+
+namespace example_behaviors
+{
+/**
+ * @brief Given an existing MTC Task object and a target grasp pose, appends MTC stages to describe a motion plan to
+ * approach, grasp, and lift an object at that pose.
+ *
+ * @details
+ * | Data Port Name | Port Type     | Object Type                                     |
+ * | -------------- |---------------|-------------------------------------------------|
+ * | task           | Bidirectional | std::shared_ptr<moveit::task_constructor::Task> |
+ * | grasp_pose     | Input         | geometry_msgs::msg::PoseStamped                 |
+ */
+class SetupMtcPlaceFromPose final : public moveit_studio::behaviors::SharedResourcesNode<BT::SyncActionNode>
+{
+public:
+  SetupMtcPlaceFromPose(const std::string& name, const BT::NodeConfiguration& config,
+                        const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
+
+  static BT::PortsList providedPorts();
+
+  static BT::KeyValueVector metadata();
+
+  BT::NodeStatus tick() override;
+};
+}  // namespace example_behaviors

--- a/include/example_behaviors/setup_mtc_wave_hand.hpp
+++ b/include/example_behaviors/setup_mtc_wave_hand.hpp
@@ -1,0 +1,84 @@
+
+
+#pragma once
+
+#include <behaviortree_cpp/action_node.h>
+#include <moveit_studio_behavior_interface/shared_resources_node.hpp>
+#include <moveit_studio_behavior_interface/behavior_context.hpp>
+#include <moveit_studio_behavior_interface/check_for_error.hpp>
+#include <moveit_studio_behavior_interface/async_behavior_base.hpp>
+
+namespace example_behaviors
+{
+/**
+ * @brief The SetupMTCWaveHand behavior makes any robot move the end of its arm back and forth.
+ * @details This is an example of a behavior that uses MoveIt Task Constructor to configure an MTC task,
+ * which can be planned and executed by MoveIt Pro's core PlanMTCTask and ExecuteMTCTask Behaviors.
+ * It is derived from AsyncBehaviorBase, an extension of the templated SharedResourcesNode type,
+ * which augments the core BehaviorTree.Cpp types with an additional constructor parameter
+ * to allow the Behavior to access a rclcpp Node owned by the Agent's ObjectiveServerNode.
+ * The AsyncBehaviorBase requires a user-implemented function doWork()
+ * which is called within an async process in a separate thread.
+ * It returns an tl::expected which contains a bool indicating task success
+ * If the task fails, doWork() returns a tl::unexpected which contains a string indicating the error
+ * if the process completed successfully or was canceled,
+ * or an error message if the process failed unexpectedly.
+ */
+class SetupMTCWaveHand final : public moveit_studio::behaviors::AsyncBehaviorBase
+{
+public:
+  /**
+   * @brief Constructor for the SetupMTCWaveHand behavior.
+   * @param name The name of a particular instance of this Behavior. This will be set by the behavior
+   * tree factory when this Behavior is created within a new behavior tree.
+   * @param shared_resources A shared_ptr to a BehaviorContext that is shared among all
+   * SharedResourcesNode Behaviors in the behavior tree. This BehaviorContext is owned by the MoveIt Pro
+   * Agent's ObjectiveServerNode.
+   * @param config This contains runtime configuration info for this Behavior, such as the mapping
+   * between the Behavior's data ports on the behavior tree's blackboard. This will be set by the
+   * behavior tree factory when this Behavior is created within a new behavior tree.
+   */
+  SetupMTCWaveHand(const std::string& name, const BT::NodeConfiguration& config,
+                   const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
+
+  /**
+   * @brief Implementation of the required providedPorts() function for the SetupMTCWaveHand Behavior.
+   * @details The BehaviorTree.CPP library requires that Behaviors must implement a static function
+   * named providedPorts() which defines their input and output ports. If the Behavior does not use
+   * any ports, this function must return an empty BT::PortsList.
+   * This function returns a list of ports with their names and port info, which is used internally
+   * by the behavior tree.
+   * @return SetupMTCWaveHand has one data port: a bidirectional port named "task", which is a shared_ptr
+   * to an MTC task object. This function returns a BT::PortsList that declares this single port.
+   */
+  static BT::PortsList providedPorts();
+
+  /**
+   * @brief Implementation of the metadata() function for displaying metadata, such as Behavior description and
+   * subcategory, in the MoveIt Studio Developer Tool.
+   * @return A BT::KeyValueVector containing the Behavior metadata.
+   */
+  static BT::KeyValueVector metadata();
+
+private:
+  /**
+   * @brief Async thread for SetupMTCWaveHand. Adds MTC stages to an MTC task provided on a data port.
+   * @details This function is where the Behavior performs its work asynchronously while the behavior tree ticks.
+   * It is very important that behaviors return from being ticked very quickly because if it blocks before returning
+   * it will block execution of the entire behavior tree, which may have undesirable consequences for other Behaviors
+   * that require a fast update rate to work correctly.
+   * @return An tl::expected which contains a true if the MTC stages were configured and added to the MTC task,
+   * or a string if it failed to retrieve the MTC task from the "task" data port.
+   */
+  tl::expected<bool, std::string> doWork() override;
+
+  /** @brief Classes derived from AsyncBehaviorBase must implement getFuture() so that it returns a shared_future class member */
+  std::shared_future<tl::expected<bool, std::string>>& getFuture() override
+  {
+    return future_;
+  }
+
+  /** @brief Classes derived from AsyncBehaviorBase must have this shared_future as a class member */
+  std::shared_future<tl::expected<bool, std::string>> future_;
+};
+}  // namespace example_behaviors

--- a/objectives/pick_and_place_example.xml
+++ b/objectives/pick_and_place_example.xml
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<root BTCPP_format="4" main_tree_to_execute="Pick And Place Example">
+  <!-- ////////// -->
+  <BehaviorTree ID="Pick And Place Example" _description="Pick and place example objective" _favorite="true" _hardcoded="false">
+    <Control ID="Sequence" name="Pick and Place">
+      <SubTree ID="Open Gripper"/>
+      <Control ID="Sequence" name="Pick">
+        <Action ID="CreateStampedPose" reference_frame="world" position_xyz="0.01;.75;0.515" orientation_xyzw="0;1;0;0" stamped_pose="{pick_pose}"/>
+        <Action ID="InitializeMTCTask" task_id="pick_task" controller_names="/joint_trajectory_controller /robotiq_gripper_controller" task="{mtc_pick_task}"/>
+        <Action ID="SetupMTCCurrentState" task="{mtc_pick_task}"/>
+        <Action ID="SetupMtcPickFromPose" grasp_pose="{pick_pose}" task="{mtc_pick_task}"/>
+        <Action ID="PlanMTCTask" task="{mtc_pick_task}" solution="{mtc_pick_solution}"/>
+        <Action ID="ExecuteMTCTask" solution="{mtc_pick_solution}"/>
+      </Control>
+      <Control ID="Sequence" name="Place">
+        <Action ID="InitializeMTCTask" task_id="place_task" controller_names="/joint_trajectory_controller /robotiq_gripper_controller" task="{mtc_place_task}"/>
+        <Action ID="SetupMTCCurrentState" task="{mtc_place_task}"/>
+        <Action ID="CreateStampedPose" reference_frame="world" position_xyz="0.01;.75;0.5.15" orientation_xyzw="0;1;0;0" stamped_pose="{place_pose}"/>
+        <Action ID="SetupMtcPlaceFromPose" place_pose="{place_pose}" task="{mtc_place_task}"/>
+        <Action ID="PlanMTCTask" task="{mtc_place_task}" solution="{mtc_place_solution}"/>
+        <Action ID="ExecuteMTCTask" solution="{mtc_place_solution}"/>
+      </Control>
+    </Control>
+  </BehaviorTree>
+</root>

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>moveit_studio_behavior_interface</depend>
+  <depend>example_interfaces</depend>
+
   <exec_depend>admittance_controller</exec_depend>
   <exec_depend>moveit_planners_stomp</exec_depend>
   <exec_depend>moveit_ros_perception</exec_depend>

--- a/src/add_two_ints_service_client.cpp
+++ b/src/add_two_ints_service_client.cpp
@@ -1,0 +1,57 @@
+#include <example_behaviors/add_two_ints_service_client.hpp>
+
+// Include the template implementation for GetMessageFromTopicBehaviorBase<T>.
+#include <moveit_studio_behavior_interface/impl/service_client_behavior_base_impl.hpp>
+namespace example_behaviors
+{
+AddTwoIntsServiceClient::AddTwoIntsServiceClient(
+    const std::string& name, const BT::NodeConfiguration& config,
+    const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources)
+  : ServiceClientBehaviorBase<example_interfaces::srv::AddTwoInts>(name, config, shared_resources)
+{
+}
+
+BT::PortsList AddTwoIntsServiceClient::providedPorts()
+{
+  // This node has three input ports and one output port
+  return BT::PortsList({
+      BT::InputPort<std::string>("service_name", "/add_two_ints", "The name of the service to call."),
+      BT::InputPort<int>("addend1", "The first int to add to the other."),
+      BT::InputPort<int>("addend2", "The second int to add to the other."),
+      BT::OutputPort<int>("result", "{result}", "Result of the AddTwoInts service."),
+  });
+}
+
+BT::KeyValueVector AddTwoIntsServiceClient::metadata()
+{
+  return { { "subcategory", "Example" },
+           { "description", "Calls a service to add two integers and makes the result available on an output port." } };
+}
+
+tl::expected<std::string, std::string> AddTwoIntsServiceClient::getServiceName()
+{
+  const auto service_name = getInput<std::string>("service_name");
+  if (const auto error = moveit_studio::behaviors::maybe_error(service_name))
+  {
+    return tl::make_unexpected("Failed to get required value from input data port: " + error.value());
+  }
+  return service_name.value();
+}
+
+tl::expected<AddTwoInts::Request, std::string> AddTwoIntsServiceClient::createRequest()
+{
+  const auto a = getInput<int>("addend1");
+  const auto b = getInput<int>("addend2");
+  if (const auto error = moveit_studio::behaviors::maybe_error(a, b))
+  {
+    return tl::make_unexpected("Failed to get required value from input data port: " + error.value());
+  }
+  return example_interfaces::build<AddTwoInts::Request>().a(a.value()).b(b.value());
+}
+
+tl::expected<bool, std::string> AddTwoIntsServiceClient::processResponse(const AddTwoInts::Response& response)
+{
+  setOutput<int>("result", response.sum);
+  return { true };
+}
+}  // namespace example_behaviors

--- a/src/delayed_message.cpp
+++ b/src/delayed_message.cpp
@@ -1,0 +1,77 @@
+#include <example_behaviors/delayed_message.hpp>
+
+namespace example_behaviors
+{
+DelayedMessage::DelayedMessage(const std::string& name, const BT::NodeConfiguration& config,
+                               const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources)
+  : moveit_studio::behaviors::SharedResourcesNode<BT::StatefulActionNode>(name, config, shared_resources)
+{
+}
+
+BT::PortsList DelayedMessage::providedPorts()
+{
+  // delay_duration: Number of seconds to wait before logging a message
+  return BT::PortsList(
+      { BT::InputPort<double>("delay_duration", "5", "The duration, in seconds, to wait before logging a message.") });
+}
+
+BT::KeyValueVector DelayedMessage::metadata()
+{
+  return { { "subcategory", "Example" },
+           { "description", "After some time, log a message that says \"Hello, world!\"." } };
+}
+
+BT::NodeStatus DelayedMessage::onStart()
+{
+  // Store the time at which this node was first ticked
+  start_time_ = std::chrono::steady_clock::now();
+
+  // getInput returns a BT::Expected so we'll store the result temporarily while we check if it was set correctly
+  const auto maybe_duration = getInput<double>("delay_duration");
+
+  // The maybe_error function returns a std::optional with an error message if the port was set incorrectly
+  if (const auto error = moveit_studio::behaviors::maybe_error(maybe_duration); error)
+  {
+    // If the port was set incorrectly, we will log an error message to the UI and the node will return FAILURE
+    shared_resources_->logger->publishFailureMessage(name(), "Failed to get required values from input data ports." +
+                                                                 error.value());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  // Store the value of the port
+  delay_duration_ = maybe_duration.value();
+
+  // If the duration is zero, we can log the message immediately
+  if (delay_duration_ <= 0)
+  {
+    // Log the "Hello, world!" message.
+    // Setting the third argument to false ensures the message will be shown immediately
+    shared_resources_->logger->publishInfoMessage(name(), "Hello, world!");
+    return BT::NodeStatus::SUCCESS;
+  }
+
+  return BT::NodeStatus::RUNNING;
+}
+
+BT::NodeStatus DelayedMessage::onRunning()
+{
+  // If the delay duration has not elapsed since this node was started, return RUNNING
+  if (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - start_time_).count() <
+      delay_duration_)
+  {
+    // Log the "Hello, world!" message.
+    // Setting the third argument to false ensures the message will be shown immediately
+    shared_resources_->logger->publishInfoMessage(name(), "Hello, world!");
+    return BT::NodeStatus::SUCCESS;
+  }
+  else
+  {
+    return BT::NodeStatus::SUCCESS;
+  }
+}
+
+void DelayedMessage::onHalted()
+{
+}
+
+}  // namespace example_behaviors

--- a/src/fibonacci_action_client.cpp
+++ b/src/fibonacci_action_client.cpp
@@ -1,0 +1,89 @@
+#include <example_behaviors/fibonacci_action_client.hpp>
+
+// Include the template implementation for ActionClientBehaviorBase<T>.
+#include <moveit_studio_behavior_interface/impl/action_client_behavior_base_impl.hpp>
+
+namespace example_behaviors
+{
+FibonacciActionClient::FibonacciActionClient(
+    const std::string& name, const BT::NodeConfiguration& config,
+    const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources)
+  : ActionClientBehaviorBase<Fibonacci>(name, config, shared_resources)
+{
+}
+
+BT::PortsList FibonacciActionClient::providedPorts()
+{
+  // This node has two input ports and two output ports
+  return BT::PortsList({
+      BT::InputPort<std::string>("action_name", "/fibonacci", "The name of the action to send a goal to."),
+      BT::InputPort<std::size_t>("order", "The order of the Fibonacci sequence"),
+      BT::OutputPort<std::vector<int>>("feedback", "{feedback}",
+                                       "The action feedback containing the latest element in the current Fibonacci "
+                                       "sequence."),
+      BT::OutputPort<std::vector<int>>(
+          "result", "{result}", "The result containing the entire Fibonacci sequence up to the specified order."),
+  });
+}
+
+BT::KeyValueVector FibonacciActionClient::metadata()
+{
+  return { { "subcategory", "Example" },
+           { "description",
+             "Calls an action to get a Fibonacci sequence and makes the result available on an output port." } };
+}
+
+tl::expected<std::string, std::string> FibonacciActionClient::getActionName()
+{
+  const auto action_name = getInput<std::string>("action_name");
+  if (const auto error = moveit_studio::behaviors::maybe_error(action_name))
+  {
+    return tl::make_unexpected("Failed to get required value from input data port: " + error.value());
+  }
+  return action_name.value();
+}
+
+tl::expected<Fibonacci::Goal, std::string> FibonacciActionClient::createGoal()
+{
+  const auto order = getInput<std::size_t>("order");
+
+  if (const auto error = moveit_studio::behaviors::maybe_error(order))
+  {
+    return tl::make_unexpected("Failed to get required value from input data port: " + error.value());
+  }
+
+  return example_interfaces::build<Fibonacci::Goal>().order(order.value());
+}
+
+tl::expected<bool, std::string> FibonacciActionClient::processResult(const std::shared_ptr<Fibonacci::Result> result)
+{
+  std::stringstream stream;
+  for (const auto& value : result->sequence)
+  {
+    stream << value << " ";
+  }
+  std::cout << stream.str() << std::endl;
+
+  // Publish the result to the UI
+  shared_resources_->logger->publishInfoMessage(name(), "Result: " + stream.str());
+
+  setOutput<std::vector<int>>("result", result->sequence);
+
+  return { true };
+}
+
+void FibonacciActionClient::processFeedback(const std::shared_ptr<const Fibonacci::Feedback> feedback)
+{
+  std::stringstream stream;
+  for (const auto& value : feedback->sequence)
+  {
+    stream << value << " ";
+  }
+  std::cout << stream.str() << std::endl;
+
+  // Publish the feedback to the UI
+  shared_resources_->logger->publishInfoMessage(name(), "Feedback: " + stream.str());
+
+  setOutput<std::vector<int>>("feedback", feedback->sequence);
+}
+}  // namespace example_behaviors

--- a/src/get_string_from_topic.cpp
+++ b/src/get_string_from_topic.cpp
@@ -1,0 +1,32 @@
+#include <example_behaviors/get_string_from_topic.hpp>
+
+// Include the template implementation for GetMessageFromTopicBehaviorBase<T>.
+#include <moveit_studio_behavior_interface/impl/get_message_from_topic_impl.hpp>
+
+namespace example_behaviors
+{
+GetStringFromTopic::GetStringFromTopic(const std::string& name, const BT::NodeConfiguration& config,
+                                       const std::shared_ptr<BehaviorContext>& shared_resources)
+  : GetMessageFromTopicBehaviorBase<std_msgs::msg::String>(name, config, shared_resources)
+{
+}
+
+BT::PortsList GetStringFromTopic::providedPorts()
+{
+  // This node has one input port and one output port
+  return BT::PortsList({
+      BT::InputPort<std::string>("topic_name", "/chatter", "The name of the topic the Behavior subscribes to."),
+      BT::OutputPort<std::vector<int>>("message_out", "{my_string}", "The output String message."),
+  });
+}
+
+BT::KeyValueVector GetStringFromTopic::metadata()
+{
+  return { { "subcategory", "Example" },
+           { "description", "Captures a string message and makes it available on an output port." } };
+}
+
+}  // namespace example_behaviors
+
+// Template specialization of GetMessageFromTopicBehaviorBase<T> for the String message type
+template class moveit_studio::behaviors::GetMessageFromTopicBehaviorBase<std_msgs::msg::String>;

--- a/src/hello_world.cpp
+++ b/src/hello_world.cpp
@@ -1,0 +1,31 @@
+#include <example_behaviors/hello_world.hpp>
+
+namespace example_behaviors
+{
+HelloWorld::HelloWorld(const std::string& name, const BT::NodeConfiguration& config,
+                       const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources)
+  : moveit_studio::behaviors::SharedResourcesNode<BT::SyncActionNode>(name, config, shared_resources)
+{
+}
+
+BT::PortsList HelloWorld::providedPorts()
+{
+  // This node has no input or output ports
+  return BT::PortsList({});
+}
+
+BT::KeyValueVector HelloWorld::metadata()
+{
+  return { { "subcategory", "Example" }, { "description", "Log a message that says \"Hello, world!\"." } };
+}
+
+BT::NodeStatus HelloWorld::tick()
+{
+  // Do HelloWorld's useful work.
+  // Setting the third argument to false ensures the message will be shown immediately
+  shared_resources_->logger->publishInfoMessage(name(), "Hello, world!");
+
+  return BT::NodeStatus::SUCCESS;
+}
+
+}  // namespace example_behaviors

--- a/src/publish_color_rgba.cpp
+++ b/src/publish_color_rgba.cpp
@@ -1,0 +1,34 @@
+#include <example_behaviors/publish_color_rgba.hpp>
+
+namespace example_behaviors
+{
+PublishColorRGBA::PublishColorRGBA(const std::string& name, const BT::NodeConfiguration& config,
+                                   const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources)
+  : moveit_studio::behaviors::SharedResourcesNode<BT::SyncActionNode>(name, config, shared_resources)
+  , publisher_{ shared_resources_->node->create_publisher<std_msgs::msg::ColorRGBA>("/my_topic", rclcpp::QoS(1)) }
+{
+}
+
+BT::PortsList PublishColorRGBA::providedPorts()
+{
+  return {};
+}
+
+BT::KeyValueVector PublishColorRGBA::metadata()
+{
+  return { { "subcategory", "Example" },
+           { "description", "Publishes a fixed std_msgs::msg::ColorRGBA message to a topic named \"/my_topic\"" } };
+}
+
+BT::NodeStatus PublishColorRGBA::tick()
+{
+  std_msgs::msg::ColorRGBA color_msg;
+  color_msg.r = 0.5;
+  color_msg.g = 0.5;
+  color_msg.b = 0.5;
+  color_msg.a = 0.5;
+  publisher_->publish(color_msg);
+
+  return BT::NodeStatus::SUCCESS;
+}
+}  // namespace example_behaviors

--- a/src/register_behaviors.cpp
+++ b/src/register_behaviors.cpp
@@ -1,0 +1,42 @@
+#include <behaviortree_cpp/bt_factory.h>
+#include <moveit_studio_behavior_interface/behavior_context.hpp>
+#include <moveit_studio_behavior_interface/shared_resources_node_loader.hpp>
+
+#include <example_behaviors/hello_world.hpp>
+#include <example_behaviors/delayed_message.hpp>
+#include <example_behaviors/setup_mtc_wave_hand.hpp>
+#include <example_behaviors/add_two_ints_service_client.hpp>
+#include <example_behaviors/fibonacci_action_client.hpp>
+#include <example_behaviors/get_string_from_topic.hpp>
+#include <example_behaviors/publish_color_rgba.hpp>
+#include <example_behaviors/setup_mtc_pick_from_pose.hpp>
+#include <example_behaviors/setup_mtc_place_from_pose.hpp>
+
+#include <pluginlib/class_list_macros.hpp>
+
+namespace example_behaviors
+{
+class ExampleBehaviorsLoader : public moveit_studio::behaviors::SharedResourcesNodeLoaderBase
+{
+public:
+  void registerBehaviors(BT::BehaviorTreeFactory& factory,
+                         const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources) override
+  {
+    moveit_studio::behaviors::registerBehavior<HelloWorld>(factory, "HelloWorld", shared_resources);
+    moveit_studio::behaviors::registerBehavior<DelayedMessage>(factory, "DelayedMessage", shared_resources);
+    moveit_studio::behaviors::registerBehavior<SetupMTCWaveHand>(factory, "SetupMTCWaveHand", shared_resources);
+    moveit_studio::behaviors::registerBehavior<GetStringFromTopic>(factory, "GetStringFromTopic", shared_resources);
+    moveit_studio::behaviors::registerBehavior<AddTwoIntsServiceClient>(factory, "AddTwoIntsServiceClient",
+                                                                        shared_resources);
+    moveit_studio::behaviors::registerBehavior<FibonacciActionClient>(factory, "FibonacciActionClient",
+                                                                      shared_resources);
+    moveit_studio::behaviors::registerBehavior<PublishColorRGBA>(factory, "PublishColorRGBA", shared_resources);
+    moveit_studio::behaviors::registerBehavior<SetupMtcPickFromPose>(factory, "SetupMtcPickFromPose", shared_resources);
+    moveit_studio::behaviors::registerBehavior<SetupMtcPlaceFromPose>(factory, "SetupMtcPlaceFromPose",
+                                                                      shared_resources);
+  }
+};
+}  // namespace example_behaviors
+
+PLUGINLIB_EXPORT_CLASS(example_behaviors::ExampleBehaviorsLoader,
+                       moveit_studio::behaviors::SharedResourcesNodeLoaderBase);

--- a/src/setup_mtc_pick_from_pose.cpp
+++ b/src/setup_mtc_pick_from_pose.cpp
@@ -1,0 +1,247 @@
+#include <example_behaviors/setup_mtc_pick_from_pose.hpp>
+
+#include <behaviortree_cpp/bt_factory.h>
+#include <moveit/task_constructor/stages.h>
+#include <moveit/task_constructor/solvers.h>
+#include <moveit/task_constructor/task.h>
+#include <moveit_msgs/msg/collision_object.hpp>
+#include <moveit_studio_behavior_interface/behavior_context.hpp>
+#include <moveit_studio_behavior_interface/check_for_error.hpp>
+#include <moveit_studio_common/utils/yaml_parsing_tools.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
+#include <tf2_eigen/tf2_eigen.hpp>
+#include <yaml-cpp/yaml.h>
+
+namespace
+{
+const auto kLogger = rclcpp::get_logger("SetupMTCPickFromPose");
+using MoveItErrorCodes = moveit_msgs::msg::MoveItErrorCodes;
+
+// Port names for input and output ports.
+constexpr auto kPortIDTask = "task";
+constexpr auto kPortIDGraspPose = "grasp_pose";
+
+// Behavior constants
+constexpr auto kWorldFrame = "world";
+constexpr auto kArmGroupName = "manipulator";
+constexpr auto kEndEffectorGroupName = "gripper";
+constexpr auto kEndEffectorName = "moveit_ee";
+constexpr auto kHandFrameName = "grasp_link";
+constexpr auto kHandCloseName = "close";
+constexpr auto kApproachDistance = 0.1;
+constexpr auto kPropertyNameTrajectoryExecutionInfo = "trajectory_execution_info";
+constexpr auto kIKTimeoutSeconds = 1.0;
+constexpr auto kMaxIKSolutions = 20;
+constexpr auto kSceneObjectNameOctomap = "<octomap>";
+}  // namespace
+
+namespace example_behaviors
+{
+SetupMtcPickFromPose::SetupMtcPickFromPose(
+    const std::string& name, const BT::NodeConfiguration& config,
+    const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources)
+  : moveit_studio::behaviors::SharedResourcesNode<BT::SyncActionNode>(name, config, shared_resources)
+{
+}
+
+BT::PortsList SetupMtcPickFromPose::providedPorts()
+{
+  return {
+    BT::BidirectionalPort<moveit::task_constructor::TaskPtr>(kPortIDTask, "{mtc_task}", "MoveIt Task Constructor task."),
+    BT::InputPort<geometry_msgs::msg::PoseStamped>(kPortIDGraspPose, "{pick_pose}",
+                                                   "The stamped pose message used in this MTC stage."),
+  };
+}
+
+BT::KeyValueVector SetupMtcPickFromPose::metadata()
+{
+  return { { "subcategory", "Example" },
+           { "description", "Adds the stages to describe a pick motion to the MTC task." } };
+}
+
+BT::NodeStatus SetupMtcPickFromPose::tick()
+{
+  using namespace moveit_studio::behaviors;
+
+  // ----------------------------------------
+  // Load data from the behavior input ports.
+  // ----------------------------------------
+  const auto grasp_pose = getInput<geometry_msgs::msg::PoseStamped>(kPortIDGraspPose);
+  const auto task = getInput<moveit::task_constructor::TaskPtr>(kPortIDTask);
+
+  // Check that all required input data ports were set
+  if (const auto error = maybe_error(grasp_pose, task); error)
+  {
+    shared_resources_->logger->publishFailureMessage(name(), "Failed to get required value from input data port: " +
+                                                                 error.value());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  // Create planners
+  const auto mtc_pipeline_planner = std::make_shared<moveit::task_constructor::solvers::PipelinePlanner>(
+      shared_resources_->node, "ompl", "RRTConnectkConfigDefault");
+  const auto mtc_joint_interpolation_planner =
+      std::make_shared<moveit::task_constructor::solvers::JointInterpolationPlanner>();
+  const auto mtc_cartesian_planner = std::make_shared<moveit::task_constructor::solvers::CartesianPath>();
+
+  auto container = std::make_unique<moveit::task_constructor::SerialContainer>("Pick From Pose");
+  container->properties().set(kPropertyNameTrajectoryExecutionInfo,
+                              boost::any_cast<moveit::task_constructor::TrajectoryExecutionInfo>(
+                                  task.value()->properties().get(kPropertyNameTrajectoryExecutionInfo)));
+  container->properties().configureInitFrom(moveit::task_constructor::Stage::PARENT);
+
+  container->setProperty("group", kArmGroupName);
+  container->setProperty("hand", kEndEffectorGroupName);
+  container->setProperty("eef", kEndEffectorName);
+  container->setProperty("ik_frame", kHandFrameName);
+
+  /** Move To Pre-Grasp Pose **/
+  {
+    auto stage = std::make_unique<moveit::task_constructor::stages::Connect>(
+        "Move to Pre-Approach Pose",
+        moveit::task_constructor::stages::Connect::GroupPlannerVector{ { kArmGroupName, mtc_pipeline_planner } });
+    stage->properties().configureInitFrom(moveit::task_constructor::Stage::PARENT,
+                                          { kPropertyNameTrajectoryExecutionInfo });
+    stage->setTimeout(1.0);
+    container->add(std::move(stage));
+  }
+
+  /** Set Allowed Collisions
+      This stage forbids collisions between the gripper and the octomap before the stage (during the Move To Pre-Grasp
+      Pose stage, so the gripper doesn't collide with objects while moving into position), and allows them after this
+      stage. **/
+  {
+    auto stage =
+        std::make_unique<moveit::task_constructor::stages::ModifyPlanningScene>("Allow collision 1 (hand,object)");
+
+    stage->allowCollisions(kSceneObjectNameOctomap,
+                           task.value()
+                               ->getRobotModel()
+                               ->getJointModelGroup(kEndEffectorGroupName)
+                               ->getLinkModelNamesWithCollisionGeometry(),
+                           true);
+    container->add(std::move(stage));
+  }
+
+  const Eigen::Vector3d approach_vector{ 0.0, 0.0, kApproachDistance };
+
+  /** Approach Grasp **/
+  {
+    // Send relative move to MTC stage
+    auto stage = std::make_unique<moveit::task_constructor::stages::MoveRelative>("Approach", mtc_cartesian_planner);
+    stage->properties().configureInitFrom(moveit::task_constructor::Stage::PARENT,
+                                          { kPropertyNameTrajectoryExecutionInfo });
+    stage->restrictDirection(moveit::task_constructor::stages::MoveRelative::BACKWARD);
+    stage->setGroup(kArmGroupName);
+    stage->setIKFrame(kHandFrameName);
+
+    geometry_msgs::msg::Vector3Stamped approach_vector_msg;
+    tf2::toMsg(approach_vector, approach_vector_msg.vector);
+    approach_vector_msg.header.frame_id = kHandFrameName;
+
+    stage->setDirection(approach_vector_msg);
+    stage->setTimeout(1.0);
+    container->add(std::move(stage));
+  }
+
+  /** Set Allowed Collisions
+      This stage allows collisions between the gripper and the octomap before the stage (during the Approach Grasp
+      stage, so the gripper can move into the octomap), and forbids them after this stage. */
+  {
+    auto stage =
+        std::make_unique<moveit::task_constructor::stages::ModifyPlanningScene>("Allow collision 2 (hand,object)");
+    stage->allowCollisions(kSceneObjectNameOctomap,
+                           task.value()
+                               ->getRobotModel()
+                               ->getJointModelGroup(kEndEffectorGroupName)
+                               ->getLinkModelNamesWithCollisionGeometry(),
+                           false);
+    container->insert(std::move(stage));
+  }
+
+  /** Generate the Inverse Kinematics (IK) solutions to move to the pose specified in the "grasp_pose" input port.
+      This will generate up to kMaxIKSolutions IK solution candidates to sample from, unless the timeout specified in
+      kIKTimeoutSeconds is reached first.
+      Collision checking is ignored for IK pose generation. Solutions that result in forbidden collisions will be
+      eliminated by failures in the stages before and after this one. **/
+  {
+    // Specify pose to generate for
+    auto stage = std::make_unique<moveit::task_constructor::stages::GeneratePose>("Generate pose");
+    stage->properties().configureInitFrom(moveit::task_constructor::Stage::PARENT);
+    stage->properties().set("marker_ns", "grasp_frame");
+    stage->setPose(grasp_pose.value());
+    stage->setMonitoredStage(task.value()->stages()->findChild("current state"));  // Hook into current state
+
+    // Compute IK
+    auto wrapper = std::make_unique<moveit::task_constructor::stages::ComputeIK>("Pose IK", std::move(stage));
+    wrapper->setMaxIKSolutions(kMaxIKSolutions);
+    wrapper->setTimeout(kIKTimeoutSeconds);
+    wrapper->setIKFrame(kHandFrameName);
+    wrapper->properties().configureInitFrom(moveit::task_constructor::Stage::PARENT, { "eef", "group" });
+    wrapper->properties().configureInitFrom(moveit::task_constructor::Stage::INTERFACE, { "target_pose" });
+    wrapper->setIgnoreCollisions(true);
+    container->add(std::move(wrapper));
+  }
+
+  /** Allow Collision
+      This stage allows collisions between the gripper and object for stages after this one (during the Close Hand,
+      Lift, and Retreat stages). **/
+  {
+    auto stage =
+        std::make_unique<moveit::task_constructor::stages::ModifyPlanningScene>("Allow collision 3 (hand,object)");
+    stage->allowCollisions(kSceneObjectNameOctomap,
+                           task.value()
+                               ->getRobotModel()
+                               ->getJointModelGroup(kEndEffectorGroupName)
+                               ->getLinkModelNamesWithCollisionGeometry(),
+                           true);
+    container->insert(std::move(stage));
+  }
+
+  /** Close Hand **/
+  {
+    auto stage =
+        std::make_unique<moveit::task_constructor::stages::MoveTo>("Close hand", mtc_joint_interpolation_planner);
+    stage->properties().configureInitFrom(moveit::task_constructor::Stage::PARENT,
+                                          { kPropertyNameTrajectoryExecutionInfo });
+    stage->setGroup(kEndEffectorGroupName);
+    stage->setGoal(kHandCloseName);
+    container->add(std::move(stage));
+  }
+
+  /** Retreat **/
+  {
+    // Send relative move to MTC stage
+    auto stage = std::make_unique<moveit::task_constructor::stages::MoveRelative>("Retreat", mtc_cartesian_planner);
+    stage->properties().configureInitFrom(moveit::task_constructor::Stage::PARENT,
+                                          { kPropertyNameTrajectoryExecutionInfo });
+    stage->setGroup(kArmGroupName);
+    stage->setIKFrame(kHandFrameName);
+
+    geometry_msgs::msg::Vector3Stamped retreat_vector_msg;
+    tf2::toMsg(approach_vector * -1, retreat_vector_msg.vector);
+    retreat_vector_msg.header.frame_id = kHandFrameName;
+
+    stage->setDirection(retreat_vector_msg);
+    container->add(std::move(stage));
+  }
+
+  // Forbid Collision
+  // This stage forbids collisions between the gripper and the object for subsequent stages.
+  {
+    auto stage =
+        std::make_unique<moveit::task_constructor::stages::ModifyPlanningScene>("Forbid collision (hand,object)");
+    stage->allowCollisions(kSceneObjectNameOctomap,
+                           task.value()
+                               ->getRobotModel()
+                               ->getJointModelGroup(kEndEffectorGroupName)
+                               ->getLinkModelNamesWithCollisionGeometry(),
+                           false);
+    container->add(std::move(stage));
+  }
+
+  task.value()->add(std::move(container));
+
+  return BT::NodeStatus::SUCCESS;
+}
+}  // namespace example_behaviors

--- a/src/setup_mtc_place_from_pose.cpp
+++ b/src/setup_mtc_place_from_pose.cpp
@@ -1,0 +1,226 @@
+#include <example_behaviors/setup_mtc_place_from_pose.hpp>
+
+#include <behaviortree_cpp/bt_factory.h>
+#include <moveit/task_constructor/stages.h>
+#include <moveit/task_constructor/solvers.h>
+#include <moveit/task_constructor/task.h>
+#include <moveit_msgs/msg/collision_object.hpp>
+#include <moveit_studio_behavior_interface/behavior_context.hpp>
+#include <moveit_studio_behavior_interface/check_for_error.hpp>
+#include <moveit_studio_common/utils/yaml_parsing_tools.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
+#include <tf2_eigen/tf2_eigen.hpp>
+#include <yaml-cpp/yaml.h>
+
+namespace
+{
+const auto kLogger = rclcpp::get_logger("SetupMTCPickFromPose");
+using MoveItErrorCodes = moveit_msgs::msg::MoveItErrorCodes;
+
+// Port names for input and output ports.
+constexpr auto kPortIDTask = "task";
+constexpr auto kPortIDGraspPose = "place_pose";
+
+// Behavior constants
+constexpr auto kWorldFrame = "world";
+constexpr auto kArmGroupName = "manipulator";
+constexpr auto kEndEffectorGroupName = "gripper";
+constexpr auto kEndEffectorName = "moveit_ee";
+constexpr auto kHandFrameName = "grasp_link";
+constexpr auto kHandOpenName = "open";
+constexpr auto kHandCloseName = "close";
+constexpr auto kApproachDistance = 0.1;
+constexpr auto kPropertyNameTrajectoryExecutionInfo = "trajectory_execution_info";
+constexpr auto kIKTimeoutSeconds = 1.0;
+constexpr auto kMaxIKSolutions = 20;
+constexpr auto kSceneObjectNameOctomap = "<octomap>";
+}  // namespace
+
+namespace example_behaviors
+{
+SetupMtcPlaceFromPose::SetupMtcPlaceFromPose(
+    const std::string& name, const BT::NodeConfiguration& config,
+    const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources)
+  : moveit_studio::behaviors::SharedResourcesNode<BT::SyncActionNode>(name, config, shared_resources)
+{
+}
+
+BT::PortsList SetupMtcPlaceFromPose::providedPorts()
+{
+  return {
+    BT::BidirectionalPort<moveit::task_constructor::TaskPtr>(kPortIDTask, "{mtc_task}", "MoveIt Task Constructor task."),
+    BT::InputPort<geometry_msgs::msg::PoseStamped>(kPortIDGraspPose, "{place_pose}",
+                                                   "The stamped pose message used in this MTC stage."),
+  };
+}
+
+BT::KeyValueVector SetupMtcPlaceFromPose::metadata()
+{
+  return { { "subcategory", "Example" },
+           { "description", "Adds the stages to describe a place motion to the MTC task." } };
+}
+
+BT::NodeStatus SetupMtcPlaceFromPose::tick()
+{
+  using namespace moveit_studio::behaviors;
+
+  // ----------------------------------------
+  // Load data from the behavior input ports.
+  // ----------------------------------------
+  const auto place_pose = getInput<geometry_msgs::msg::PoseStamped>(kPortIDGraspPose);
+  const auto task = getInput<moveit::task_constructor::TaskPtr>(kPortIDTask);
+
+  // Check that all required input data ports were set
+  if (const auto error = maybe_error(place_pose, task); error)
+  {
+    shared_resources_->logger->publishFailureMessage(name(), "Failed to get required value from input data port: " +
+                                                                 error.value());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  // Create planners
+  const auto mtc_pipeline_planner =
+      std::make_shared<moveit::task_constructor::solvers::PipelinePlanner>(shared_resources_->node);
+  const auto mtc_joint_interpolation_planner =
+      std::make_shared<moveit::task_constructor::solvers::JointInterpolationPlanner>();
+  const auto mtc_cartesian_planner = std::make_shared<moveit::task_constructor::solvers::CartesianPath>();
+
+  auto container = std::make_unique<moveit::task_constructor::SerialContainer>("Place From Pose");
+  container->properties().set(kPropertyNameTrajectoryExecutionInfo,
+                              boost::any_cast<moveit::task_constructor::TrajectoryExecutionInfo>(
+                                  task.value()->properties().get(kPropertyNameTrajectoryExecutionInfo)));
+  container->properties().configureInitFrom(moveit::task_constructor::Stage::PARENT);
+
+  container->setProperty("group", kArmGroupName);
+  container->setProperty("hand", kEndEffectorGroupName);
+  container->setProperty("eef", kEndEffectorName);
+  container->setProperty("ik_frame", kHandFrameName);
+
+  /** Allow Collision since the hand holds a collision object */
+  {
+    auto stage =
+        std::make_unique<moveit::task_constructor::stages::ModifyPlanningScene>("Allow collision 2 (hand,object)");
+    stage->allowCollisions(kSceneObjectNameOctomap,
+                           task.value()
+                               ->getRobotModel()
+                               ->getJointModelGroup(kEndEffectorGroupName)
+                               ->getLinkModelNamesWithCollisionGeometry(),
+                           false);
+    container->insert(std::move(stage));
+  }
+
+  /** Move To Pre-Place Pose **/
+  {
+    auto stage = std::make_unique<moveit::task_constructor::stages::Connect>(
+        "Move to Pre-Approach Pose",
+        moveit::task_constructor::stages::Connect::GroupPlannerVector{ { kArmGroupName, mtc_pipeline_planner } });
+    stage->properties().configureInitFrom(moveit::task_constructor::Stage::PARENT);
+
+    stage->properties().set(kPropertyNameTrajectoryExecutionInfo,
+                            boost::any_cast<moveit::task_constructor::TrajectoryExecutionInfo>(
+                                container->properties().get(kPropertyNameTrajectoryExecutionInfo)));
+    stage->setTimeout(1.0);
+    container->add(std::move(stage));
+  }
+
+  const Eigen::Vector3d approach_vector{ 0.0, 0.0, kApproachDistance };
+
+  /** Approach Place Pose **/
+  {
+    // Send relative move to MTC stage
+    auto stage = std::make_unique<moveit::task_constructor::stages::MoveRelative>("Approach", mtc_cartesian_planner);
+    stage->restrictDirection(moveit::task_constructor::stages::MoveRelative::BACKWARD);
+    stage->setGroup(kArmGroupName);
+    stage->setIKFrame(kHandFrameName);
+
+    geometry_msgs::msg::Vector3Stamped approach_vector_msg;
+    tf2::toMsg(approach_vector, approach_vector_msg.vector);
+    approach_vector_msg.header.frame_id = kHandFrameName;
+
+    stage->setDirection(approach_vector_msg);
+    stage->setTimeout(10);
+    container->add(std::move(stage));
+  }
+
+  /** Generate the Inverse Kinematics (IK) solutions to move to the pose specified in the "place_pose" input port.
+      This will generate up to kMaxIKSolutions IK solution candidates to sample from, unless the timeout specified in
+      kIKTimeoutSeconds is reached first.
+      Collision checking is ignored for IK pose generation. Solutions that result in forbidden collisions will be
+      eliminated by failures in the stages before and after this one. **/
+  {
+    // Specify pose to generate for
+    auto stage = std::make_unique<moveit::task_constructor::stages::GeneratePose>("Generate pose");
+    stage->properties().configureInitFrom(moveit::task_constructor::Stage::PARENT);
+    stage->properties().set("marker_ns", "grasp_frame");
+    stage->setPose(place_pose.value());
+    stage->setMonitoredStage(task.value()->stages()->findChild("current state"));  // Hook into current state
+
+    // Compute IK
+    auto wrapper = std::make_unique<moveit::task_constructor::stages::ComputeIK>("Pose IK", std::move(stage));
+    wrapper->setMaxIKSolutions(kMaxIKSolutions);
+    wrapper->setTimeout(kIKTimeoutSeconds);
+    wrapper->setIKFrame(kHandFrameName);
+    wrapper->properties().configureInitFrom(moveit::task_constructor::Stage::PARENT, { "eef", "group" });
+    wrapper->properties().configureInitFrom(moveit::task_constructor::Stage::INTERFACE, { "target_pose" });
+    wrapper->setIgnoreCollisions(true);
+    container->add(std::move(wrapper));
+  }
+
+  /** Allow Collision
+      This stage allows collisions between the gripper and object for stages after this one (during the Close Hand,
+      Lift, and Retreat stages). */
+  {
+    auto stage =
+        std::make_unique<moveit::task_constructor::stages::ModifyPlanningScene>("Allow collision (hand,object)");
+    stage->allowCollisions(kSceneObjectNameOctomap,
+                           task.value()
+                               ->getRobotModel()
+                               ->getJointModelGroup(kEndEffectorGroupName)
+                               ->getLinkModelNamesWithCollisionGeometry(),
+                           true);
+    container->add(std::move(stage));
+  }
+
+  /** Open Hand **/
+  {
+    auto stage =
+        std::make_unique<moveit::task_constructor::stages::MoveTo>("Open hand", mtc_joint_interpolation_planner);
+    stage->setGroup(kEndEffectorGroupName);
+    stage->setGoal(kHandOpenName);
+    container->add(std::move(stage));
+  }
+
+  /** Forbid Collision
+      This stage forbids collisions between the gripper and the object for subsequent stages. **/
+  {
+    auto stage =
+        std::make_unique<moveit::task_constructor::stages::ModifyPlanningScene>("Forbid collision (hand,object)");
+    stage->allowCollisions(kSceneObjectNameOctomap,
+                           task.value()
+                               ->getRobotModel()
+                               ->getJointModelGroup(kEndEffectorGroupName)
+                               ->getLinkModelNamesWithCollisionGeometry(),
+                           false);
+    container->add(std::move(stage));
+  }
+
+  /** Retreat **/
+  {
+    // Send relative move to MTC stage
+    auto stage = std::make_unique<moveit::task_constructor::stages::MoveRelative>("Retreat", mtc_cartesian_planner);
+    stage->setGroup(kArmGroupName);
+    stage->setIKFrame(kHandFrameName);
+
+    geometry_msgs::msg::Vector3Stamped retreat_vector_msg;
+    tf2::toMsg(approach_vector * -1, retreat_vector_msg.vector);
+    retreat_vector_msg.header.frame_id = kHandFrameName;
+
+    stage->setDirection(retreat_vector_msg);
+    container->add(std::move(stage));
+  }
+
+  task.value()->add(std::move(container));
+
+  return BT::NodeStatus::SUCCESS;
+}
+}  // namespace example_behaviors

--- a/src/setup_mtc_wave_hand.cpp
+++ b/src/setup_mtc_wave_hand.cpp
@@ -1,0 +1,113 @@
+#include <example_behaviors/setup_mtc_wave_hand.hpp>
+
+#include <moveit/task_constructor/solvers.h>
+#include <moveit/task_constructor/stages.h>
+#include <moveit/task_constructor/task.h>
+
+namespace
+{
+// Define a constant for the ID of the Behavior's data port.
+constexpr auto kPortIDTask = "task";
+
+// Define constants for the names of the behavior parameters used by the SetupMTCWaveHand behavior.
+// These defaults are set to match the UR5e robot defined in the moveit_studio_custom_site_config_example package.
+constexpr auto kPrimaryGroupName = "manipulator";
+constexpr auto kHandFrameName = "grasp_link";
+
+// Create a rclcpp Logger to use when printing messages to the console.
+const rclcpp::Logger kLogger = rclcpp::get_logger("WaveHello");
+}  // namespace
+
+namespace example_behaviors
+{
+SetupMTCWaveHand::SetupMTCWaveHand(const std::string& name, const BT::NodeConfiguration& config,
+                                   const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources)
+  : moveit_studio::behaviors::AsyncBehaviorBase(name, config, shared_resources)
+{
+}
+
+BT::PortsList SetupMTCWaveHand::providedPorts()
+{
+  return {
+    BT::BidirectionalPort<std::shared_ptr<moveit::task_constructor::Task>>(kPortIDTask, "{mtc_task}",
+                                                                           "MoveIt Task Constructor task."),
+  };
+}
+
+BT::KeyValueVector SetupMTCWaveHand::metadata()
+{
+  return { { "subcategory", "Example" }, { "description", "Wave hello with the end effector." } };
+}
+
+tl::expected<bool, std::string> SetupMTCWaveHand::doWork()
+{
+  // Retrieve the "task" data port
+  const auto task = getInput<moveit::task_constructor::TaskPtr>(kPortIDTask);
+
+  // Check that all required input data ports were set
+  if (const auto error = moveit_studio::behaviors::maybe_error(task); error)
+  {
+    RCLCPP_ERROR_STREAM(kLogger, "Failed to get required values from input data ports:\n" << error.value());
+    // Task setup cannot succeed if we failed to retrieve the MTC task shared_ptr from the "task" port, so we return false.
+    return tl::make_unexpected("Failed to get required values from input data ports: " + error.value());
+  }
+
+  // Create a Cartesian path planner used to perform linear moves relative to the end effector frame.
+  auto cartesian_planner = std::make_shared<moveit::task_constructor::solvers::CartesianPath>();
+
+  // Create an MTC stage to define a motion that translates along the end effector X+ axis. Assumes that the robot is
+  // not already at its joint limits.
+
+  // Set the direction to move along as a TwistStamped.
+  geometry_msgs::msg::TwistStamped wave_first_direction;
+  wave_first_direction.header.frame_id = kHandFrameName;
+  wave_first_direction.twist.linear.x = 1.0;
+
+  // Create a new MTC stage
+  {
+    // Create a new MoveRelative stage that uses the Cartesian motion planner
+    auto stage = std::make_unique<moveit::task_constructor::stages::MoveRelative>(std::string("Wave One Direction"),
+                                                                                  cartesian_planner);
+    stage->properties().configureInitFrom(moveit::task_constructor::Stage::PARENT);
+    // Configure the stage to move the UR-5e's arm.
+    stage->setGroup(kPrimaryGroupName);
+    // Configure the stage to move relative to the UR-5e's gripper frame.
+    stage->setIKFrame(kHandFrameName);
+    // Configure the stage to move along the direction specified by the TwistStamped.
+    stage->setDirection(wave_first_direction);
+    // Set that we will move at most 0.2m along the vector.
+    stage->setMaxDistance(0.2);
+    // Add the stage to the MTC task which was retrieved from the "task" data port.
+    task.value()->add(std::move(stage));
+  }
+
+  // Create a second MTC stage to define a motion that translates along the end effector X- axis, which is the opposite
+  // motion from what we did in the previous stage.
+
+  // Set the direction to move along as a TwistStamped.
+  geometry_msgs::msg::TwistStamped wave_second_direction;
+  wave_second_direction.header.frame_id = kHandFrameName;
+  wave_second_direction.twist.linear.x = -1.0;
+
+  {
+    // Create a new MoveRelative stage that uses the Cartesian motion planner
+    auto stage = std::make_unique<moveit::task_constructor::stages::MoveRelative>(
+        std::string("Wave Opposite Direction"), cartesian_planner);
+    stage->properties().configureInitFrom(moveit::task_constructor::Stage::PARENT);
+    // Configure the stage to move the UR-5e's arm.
+    stage->setGroup(kPrimaryGroupName);
+    // Configure the stage to move relative to the UR-5e's gripper frame.
+    stage->setIKFrame(kHandFrameName);
+    // Configure the stage to move along the direction specified by the TwistStamped.
+    stage->setDirection(wave_second_direction);
+    // Set that we will move at most 0.2m along the vector.
+    stage->setMaxDistance(0.2);
+    // Add the stage to the MTC task which was retrieved from the "task" data port.
+    task.value()->add(std::move(stage));
+  }
+
+  // Once the work is done, we can return true so that the node returns SUCCESS next time it is ticked
+  return true;
+}
+
+}  // namespace example_behaviors

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,4 @@
+find_package(ament_cmake_gtest REQUIRED)
+
+ament_add_gtest(test_behavior_plugins test_behavior_plugins.cpp)
+ament_target_dependencies(test_behavior_plugins ${THIS_PACKAGE_INCLUDE_DEPENDS})

--- a/test/test_behavior_plugins.cpp
+++ b/test/test_behavior_plugins.cpp
@@ -1,0 +1,48 @@
+#include <gtest/gtest.h>
+
+#include <behaviortree_cpp/bt_factory.h>
+#include <moveit_studio_behavior_interface/shared_resources_node_loader.hpp>
+#include <pluginlib/class_loader.hpp>
+#include <rclcpp/node.hpp>
+
+/**
+ * @brief This test makes sure that the Behaviors provided in this package can be successfully registered and
+ * instantiated by the behavior tree factory.
+ */
+TEST(BehaviorTests, test_load_behavior_plugins)
+{
+  pluginlib::ClassLoader<moveit_studio::behaviors::SharedResourcesNodeLoaderBase> class_loader(
+      "moveit_studio_behavior_interface", "moveit_studio::behaviors::SharedResourcesNodeLoaderBase");
+
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto shared_resources = std::make_shared<moveit_studio::behaviors::BehaviorContext>(node);
+
+  BT::BehaviorTreeFactory factory;
+  {
+    auto plugin_instance = class_loader.createUniqueInstance("example_behaviors::ExampleBehaviorsLoader");
+    ASSERT_NO_THROW(plugin_instance->registerBehaviors(factory, shared_resources));
+  }
+  // Test that ClassLoader is able to find and instantiate each Behavior using the package's plugin description info.
+  EXPECT_NO_THROW(
+      (void)factory.instantiateTreeNode("test_behavior_name", "AddTwoIntsServiceClient", BT::NodeConfiguration()));
+  EXPECT_NO_THROW((void)factory.instantiateTreeNode("test_behavior_name", "DelayedMessage", BT::NodeConfiguration()));
+  EXPECT_NO_THROW(
+      (void)factory.instantiateTreeNode("test_behavior_name", "FibonacciActionClient", BT::NodeConfiguration()));
+  EXPECT_NO_THROW(
+      (void)factory.instantiateTreeNode("test_behavior_name", "GetStringFromTopic", BT::NodeConfiguration()));
+  EXPECT_NO_THROW((void)factory.instantiateTreeNode("test_behavior_name", "HelloWorld", BT::NodeConfiguration()));
+  EXPECT_NO_THROW((void)factory.instantiateTreeNode("test_behavior_name", "PublishColorRGBA", BT::NodeConfiguration()));
+  EXPECT_NO_THROW(
+      (void)factory.instantiateTreeNode("test_behavior_name", "SetupMtcPickFromPose", BT::NodeConfiguration()));
+  EXPECT_NO_THROW(
+      (void)factory.instantiateTreeNode("test_behavior_name", "SetupMtcPlaceFromPose", BT::NodeConfiguration()));
+  EXPECT_NO_THROW((void)factory.instantiateTreeNode("test_behavior_name", "SetupMTCWaveHand", BT::NodeConfiguration()));
+}
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Partially resolves https://github.com/PickNikRobotics/moveit_studio/issues/8992.

This PR ports over the example behaviors and the example objective that implements the custom MTC behaviors from https://github.com/PickNikRobotics/moveit_studio_example_behaviors/tree/main so that that repo can be deprecated. 

## To test
1) Compile/build this branch
2) Run the `Pick and Place Example` Objective and ensure that the robot picks up and puts down the block.